### PR TITLE
Correct ESP32 LED GPIO config

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -23,7 +23,7 @@ conds:
       libs:
         - origin: https://github.com/mongoose-os-libs/wifi
       config_schema:
-        - ["board.led1.pin", 13]
+        - ["board.led1.pin", 2]
         - ["board.btn1.pin", 0]
         - ["board.btn1.pull_up", true]
         - ["provision.btn.pin", 0]


### PR DESCRIPTION
ESP32 development boards have build-in LED at GPIO2. This PR corrects the config which wrongly set LED GPIO to 13.
https://randomnerdtutorials.com/esp32-pinout-reference-gpios/